### PR TITLE
Add nginx init.d service file

### DIFF
--- a/files/nginx
+++ b/files/nginx
@@ -1,0 +1,66 @@
+#! /bin/sh
+
+### BEGIN INIT INFO
+# Provides:          nginx
+# Required-Start:    $all
+# Required-Stop:     $all
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: starts the nginx web server
+# Description:       starts nginx using start-stop-daemon
+### END INIT INFO
+#
+# Nginx init scripts
+# https://www.nginx.com/resources/wiki/start/topics/examples/initscripts/
+# http://kbeezie.com/debian-ubuntu-nginx-init-script/
+
+PATH=/opt/bin:/opt/sbin:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+DAEMON=/usr/sbin/nginx
+NAME=nginx
+DESC=nginx
+
+test -x $DAEMON || exit 0
+
+# Include nginx defaults if available
+if [ -f /etc/default/nginx ] ; then
+        . /etc/default/nginx
+fi
+
+set -e
+
+case "$1" in
+  start)
+        echo -n "Starting $DESC: "
+        start-stop-daemon --start --oknodo --quiet --pidfile /var/run/nginx.pid \
+                --exec $DAEMON -- $DAEMON_OPTS
+        echo "$NAME."
+        ;;
+  stop)
+        echo -n "Stopping $DESC: "
+        start-stop-daemon --stop --oknodo --quiet --pidfile /var/run/nginx.pid \
+                --exec $DAEMON
+        echo "$NAME."
+        ;;
+  restart|force-reload)
+        echo -n "Restarting $DESC: "
+        start-stop-daemon --stop --oknodo --quiet --pidfile \
+                /var/run/nginx.pid --exec $DAEMON
+        sleep 1
+        start-stop-daemon --start --oknodo --quiet --pidfile \
+                /var/run/nginx.pid --exec $DAEMON -- $DAEMON_OPTS
+        echo "$NAME."
+        ;;
+  reload)
+      echo -n "Reloading $DESC configuration: "
+      start-stop-daemon --stop --signal HUP --quiet --pidfile /var/run/nginx.pid \
+          --exec $DAEMON
+      echo "$NAME."
+      ;;
+  *)
+        N=/etc/init.d/$NAME
+        echo "Usage: $N {start|stop|restart|force-reload}" >&2
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -1,3 +1,6 @@
 ---
+- name: copy nginx service file
+  copy: src=nginx dest=/etc/init.d/nginx mode=755
+
 - name: service - ensure nginx is running
   service: name=nginx state=started enabled=yes


### PR DESCRIPTION
It's needed to copy the right nginx service init.d file. When
a server already have the nginx service the debian package doesnt
install it again and it gets outdated and doesn't work properly.

So, ensuring the state of the file that we need is the best
approach.
